### PR TITLE
Removing no longer used dependencies from `debug` image

### DIFF
--- a/debug/debug.apko.yaml
+++ b/debug/debug.apko.yaml
@@ -3,7 +3,6 @@ contents:
     - https://dl-cdn.alpinelinux.org/alpine/edge/main
     - https://dl-cdn.alpinelinux.org/alpine/edge/community
   packages:
-    - aws-cli
     - bash
     - bind-tools
     - bridge-utils
@@ -27,7 +26,6 @@ contents:
     - tcpdump
     - tcptraceroute
     - util-linux
-    - vim
     - wget
 
 archs:


### PR DESCRIPTION
Removing the following packages:
- `vim`
  - Reason: `busybox-extras` depends on `busybox`, which already includes a version for `vi`.
- `aws-cli`
  - Reason: this package alone requires around 98MB in the final image, which seems too much for a package I don't regularly use.

---

`aws-cli` package

<img width="1512" alt="Screenshot 2024-03-16 at 22 06 41" src="https://github.com/hpedrorodrigues/images/assets/10264635/6d48b697-1b62-4988-9117-2c6d95dae116">


Verified with a local build:

```bash
♪ dive ghcr.io/hpedrorodrigues/debug:latest-arm64
```

---

Before

```
REPOSITORY                      TAG            IMAGE ID       CREATED        SIZE
ghcr.io/hpedrorodrigues/debug   latest-arm64   a98c4f070e47   12 hours ago   243MB
ghcr.io/hpedrorodrigues/debug   latest-amd64   99b4f1eca23a   12 hours ago   222MB
```

After

```
REPOSITORY                      TAG            IMAGE ID       CREATED        SIZE
ghcr.io/hpedrorodrigues/debug   latest-arm64   8fab0bfed548   37 hours ago   71.7MB
ghcr.io/hpedrorodrigues/debug   latest-amd64   fda078c353dd   37 hours ago   55.7MB
```