### PR TITLE
Update packages (and fix image build with apko `v0.22.2`+)

### DIFF
--- a/hadolint/hadolint.apko.yaml
+++ b/hadolint/hadolint.apko.yaml
@@ -4,7 +4,7 @@ contents:
     - '@local packages'
   packages:
     - alpine-baselayout-data
-    - hadolint@local
+    - hadolint
 
 archs:
   - x86_64

--- a/hadolint/hadolint.melange.yaml
+++ b/hadolint/hadolint.melange.yaml
@@ -22,7 +22,7 @@ pipeline:
     with:
       repository: https://github.com/hadolint/hadolint.git
       tag: v${{package.version}}
-      expected-commit: 742b76e3b9b4d45d6716771b0f1fae2fa0069104
+      expected-commit: 4ab5d7809325c8de23956a44ca5a1f3c25907faf
   - runs: |
       # Reference:
       # - https://github.com/Homebrew/homebrew-core/blob/d7b00fd733bcf99f55a20942cf980ff045f41478/Formula/h/hadolint.rb#L28-L29

--- a/hadolint/hadolint.melange.yaml
+++ b/hadolint/hadolint.melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: hadolint
-  version: 2.13.0-beta
+  version: 2.13.1-beta
   epoch: 0
   target-architecture:
     - x86_64

--- a/prettier/prettier.apko.yaml
+++ b/prettier/prettier.apko.yaml
@@ -4,7 +4,7 @@ contents:
     - '@local packages'
   packages:
     - alpine-baselayout-data
-    - prettier@local
+    - prettier
 
 archs:
   - x86_64

--- a/prettier/prettier.melange.yaml
+++ b/prettier/prettier.melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: prettier
-  version: 3.4.1
+  version: 3.4.2
   epoch: 0
   checks:
     disabled:


### PR DESCRIPTION
Hadolint and prettier builds stopped working after [apko v0.22.2](https://github.com/chainguard-dev/apko/releases/tag/v0.22.2). So, probably related to https://github.com/chainguard-dev/apko/pull/1441. After skimming the pull request changes it seems it broke compatibility with pinned versions. Also, since I'm generating these melange packages on every build I won't manually generate these lock files.